### PR TITLE
Fix iframe overflow and button layout on mobile

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1782,6 +1782,22 @@ body.mobile-nav-active #mobile-nav-toggle {
   background: #111;
   border: 2px solid #000000;
   color: #fff;
+}
 
+/* New styles for the iframe container */
+.iframe-container {
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+  padding-top: 56.25%; /* 16:9 Aspect Ratio */
+}
+
+.iframe-container iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: none;
 }
 

--- a/index.html
+++ b/index.html
@@ -194,14 +194,13 @@
       <section id="skills">
             <div class="container">
                 <div class="row align-items-center">
-                    <div class="col-lg-6 col-md-6 order-2 order-md-1 wow fadeInUp" data-wow-delay="0.2s" style="position: relative; width: 100%; height: 100%;  padding: 200px; overflow: hidden;">
+                    <div class="col-lg-6 col-md-6 order-2 order-md-1 wow fadeInUp iframe-container" data-wow-delay="0.2s">
                       <iframe src="https://www.youtube.com/embed/KLM0Gmij1UU?autoplay=1" 
                               title="Canva for Beginners: Remake Pepsodent Poster AD with Canva" 
                               frameborder="0" 
                               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
                               referrerpolicy="strict-origin-when-cross-origin" 
-                              allowfullscreen
-                              style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border: none;">
+                              allowfullscreen>
                       </iframe>
                     </div><!--end col-->
 
@@ -216,14 +215,14 @@
                             <div class="row">
                                 
                                 
-                                <div class="col-lg-6 mt-4 pt-2">
+                                <div class="col-lg-6 col-6 mt-4 pt-2">
                                     <div class="media align-items-center rounded p-3">     
                                         <a class="cta-btn icon" href="#call-to-action" rel="noopener noreferrer" aria-label="Download Nsawa App on Google Play Store and Apple App Store">
                                             <ion-icon name="phone-portrait-outline" ></ion-icon> get App 
                                         </a>
                                     </div>
                                 </div>
-                                <div class="col-lg-6 mt-4 pt-2">
+                                <div class="col-lg-6 col-6 mt-4 pt-2">
                                     <div class="media align-items-center rounded  p-3">                                        
                                       <a class="cta-btn icon" href="#" rel="noopener noreferrer" aria-label="Sign up for a free Nsawa account">
                                           <ion-icon name="person-add-outline"></ion-icon> Free Sign Up </a>


### PR DESCRIPTION
This commit addresses two layout issues on mobile devices:

1. The YouTube iframe in the 'about' section now scales correctly and does not overflow its container. This was fixed by removing inline styles and using a responsive CSS class to maintain the aspect ratio.

2. The two buttons in the 'about' section are now displayed side-by-side on mobile view, as requested. This was achieved by adding the 'col-6' Bootstrap class to their container divs.